### PR TITLE
Update Type Hint in Hello QMI

### DIFF
--- a/notebooks/qcs-only/HelloQMI.ipynb
+++ b/notebooks/qcs-only/HelloQMI.ipynb
@@ -29,7 +29,7 @@
     "import math\n",
     "import os\n",
     "import sys\n",
-    "from typing import Dict, Optional\n",
+    "from typing import Optional\n",
     "\n",
     "from pyquil import Program, get_qc\n",
     "from pyquil.api import QVM\n",
@@ -51,7 +51,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def query_device(device_name) -> Optional[Dict[str, str]]:\n",
+    "def query_device(device_name) -> Optional[dict[str, str]]:\n",
     "    \"\"\"\n",
     "    Try to query the device from QCS. Return the lattice dict if it exists,\n",
     "    or None otherwise.\n",


### PR DESCRIPTION
I recently made a PR that included a change to a type hint for a function returning a dictionary, but I didn't know at the time that `typing.Dict` [is deprecated as of 3.9](https://docs.python.org/3/library/typing.html#typing.Dict) in favor of `builtins.dict`. My apologies!